### PR TITLE
modify generated tests to cater for project names with hyphen

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Poetry (spark-cookiecutter) (2)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Poetry (JumpSpark)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/spark-cookiecutter.iml
+++ b/.idea/spark-cookiecutter.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/angelou" isTestSource="false" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Poetry (JumpSpark)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
   "project_name": "new-project",
-  "package_name": "{{cookiecutter.project_name|lower|replace(' ', '_')|replace('-', '_')}}",
+  "package_name": "{{cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_')}}",
   "project_version": "0.1.0",
   "full_name": "Your Name",
   "email": "Your Email",

--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -33,6 +33,22 @@ def test_run_cookiecutter_result(cookies):
         assert "project_name" not in readme
 
 
+def test_run_cookiecutter_result_with_hyphen_in_projectname(cookies):
+    """Runs cookiecutter and checks if the appropriate package names are initialized"""
+    project_name = "random-project"
+    package_name = "random_project"
+    result = cookies.bake(
+        extra_context={"project_name": project_name}
+
+    )
+    project_path_tests = result.project_path/"tests"/"test_transformations.py"
+    assert project_path_tests.is_file()
+    with open(project_path_tests,"r") as f:
+        test_transformations =f.read()
+        assert project_name not in test_transformations
+        assert package_name in test_transformations
+
+
 def test_cookiecutter_generated_files(cookies):
     """tests the generated files names make sense"""
     re_bad = re.compile(r"{{\s?cookiecutter\..*?}}")
@@ -42,7 +58,6 @@ def test_cookiecutter_generated_files(cookies):
         re_bad.search(str(file_path)) is None
         for file_path in result.project_path.glob("*")
     )
-
 
 def test_cookiecutter_make_qa(cookies):
     """runs tests on the generated dir"""

--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -1,8 +1,189 @@
+### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
-tests/__pycache__/*.pyc
 *.py[cod]
+*$py.class
 
-.pytest_cache/
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
 dist/
-angelou.egg-info/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+.vscode/*.code-snippets
+
+# Ignore code-workspaces
+*.code-workspace
+
+# Idea
+.idea

--- a/{{cookiecutter.project_name}}/tests/test_transformations.py
+++ b/{{cookiecutter.project_name}}/tests/test_transformations.py
@@ -3,8 +3,8 @@ import pytest
 from pyspark.sql.types import *
 from quinn.extensions import *
 
-import {{cookiecutter.project_name}}.sparksession as S
-import {{cookiecutter.project_name}}.transformations as T
+import {{cookiecutter.package_name}}.sparksession as S
+import {{cookiecutter.package_name}}.transformations as T
 
 import chispa
 

--- a/{{cookiecutter.project_name}}/tests/test_{{cookiecutter.project_name}}.py
+++ b/{{cookiecutter.project_name}}/tests/test_{{cookiecutter.project_name}}.py
@@ -1,4 +1,4 @@
-from {{cookiecutter.project_name}} import __version__
+from {{cookiecutter.package_name}} import __version__
 
 
 def test_version():


### PR DESCRIPTION
Hello @Spratiher9 ,

Great project.
Have observed one issue,
when the project is initialised with a hyphen the module imported references the project name rather than the package name
This causes module not found errors when the project name is initialised with a hyphen after the Pyspark project is initialised